### PR TITLE
First attempt at wrapping ABCpy - work-in-progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ sbi-logs/
 # Editors
 .tags
 .vscode
+.idea
 
 # macOS
 *.DS_Store

--- a/sbibm/algorithms/abcpy/abcpy_utils.py
+++ b/sbibm/algorithms/abcpy/abcpy_utils.py
@@ -1,0 +1,115 @@
+from typing import Callable
+import torch
+import numpy as np
+from abcpy.continuousmodels import Continuous, InputConnector
+from abcpy.distances import Euclidean, LogReg, PenLogReg
+from abcpy.output import Journal
+from abcpy.probabilisticmodels import ProbabilisticModel
+from abcpy.statistics import Statistics
+
+
+class ABCpyPrior(ProbabilisticModel, Continuous):
+    def __init__(self, task, name='ABCpy_prior'):
+        self.prior_forward = task.get_prior()
+        self.dim_parameters = task.dim_parameters
+        self.name = task.name if task.name is not None else name
+
+        input_parameters = InputConnector.from_list([])
+        super(ABCpyPrior, self).__init__(input_parameters, self.name + "_prior")
+
+    def forward_simulate(self, abcpy_input_values, num_forward_simulations, rng=np.random.RandomState()):
+        result = np.array(self.prior_forward(num_forward_simulations))
+        # print(num_forward_simulations, result.shape)
+        return [np.array([x]).reshape(-1, ) for x in result]
+
+    def get_output_dimension(self):
+        return self.dim_parameters
+
+    def _check_input(self, input_values):
+        return True
+
+    def _check_output(self, values):
+        return True
+
+
+class ABCpySimulator(ProbabilisticModel, Continuous):
+    def __init__(self, parameters, task, num_simulations, name='ABCpy_simulator'):
+        self.simulator = task.get_simulator(max_calls=num_simulations)
+        self.output_dim = task.dim_data
+        self.name = task.name if task.name is not None else name
+
+        input_parameters = InputConnector.from_list(parameters)
+        super(ABCpySimulator, self).__init__(input_parameters, self.name)
+
+    def forward_simulate(self, abcpy_input_values, num_forward_simulations, rng=np.random.RandomState()):
+        tensor_param = torch.tensor(abcpy_input_values)
+        tensor_res = [self.simulator(tensor_param) for k in range(num_forward_simulations)]
+        # print(tensor_res)
+        # print([np.array(x).reshape(-1, ) for x in tensor_res])
+        return [np.array(x).reshape(-1, ) for x in tensor_res]
+
+    def get_output_dimension(self):
+        return self.output_dim
+
+    def _check_input(self, input_values):
+        return True
+
+    def _check_output(self, values):
+        return True
+
+
+def get_distance(distance: str, statistics: Statistics) -> Callable:
+    """Return distance function for ABCpy."""
+
+    if distance == "l2":
+        distance_calc = Euclidean(statistics)
+
+    elif distance == "log_reg":
+        distance_calc = LogReg(statistics)
+
+    elif distance == "pen_log_reg":
+        distance_calc = PenLogReg(statistics)
+
+    elif distance == "Wasserstein":
+        raise NotImplementedError("Wasserstein distace not yet implemented as we are considering only one single "
+                                  "simulation for parameter value")
+
+    else:
+        raise NotImplementedError(f"Distance '{distance}' not implemented.")
+
+    return distance_calc
+
+
+def journal_cleanup_rejABC(journal, percentile):
+    """This function takes a Journal file (typically produced by an Rejection ABC run with very large epsilon value)
+    and the keeps only the samples which achieve performance less than some percentile of the achieved distances. It is
+    a very simple way to obtain a Rejection ABC which works on a percentile of the obtained distances. """
+
+    distance_cutoff = np.percentile(journal.distances[-1], percentile)
+    picked_simulations = journal.distances[-1] < distance_cutoff
+    new_distances = journal.distances[-1][picked_simulations]
+
+    new_journal = Journal(journal._type)
+    new_journal.configuration["n_samples"] = journal.configuration["n_samples"]
+    new_journal.configuration["n_samples_per_param"] = journal.configuration["n_samples_per_param"]
+    new_journal.configuration["epsilon"] = journal.configuration["epsilon"]
+
+    n_reduced_samples = np.sum(picked_simulations)
+
+    new_accepted_parameters = []
+    param_names = journal.get_parameters().keys()
+    new_names_and_parameters = {name: [] for name in param_names}
+    for i in range(len(picked_simulations)):
+        if picked_simulations[i]:
+            new_accepted_parameters.append(journal.get_accepted_parameters()[i])
+            for name in param_names:
+                new_names_and_parameters[name].append(journal.get_parameters()[name][i])
+
+    new_journal.add_accepted_parameters(new_accepted_parameters)
+    new_journal.add_weights(np.ones((n_reduced_samples, 1)))
+    new_journal.add_ESS_estimate(np.ones((n_reduced_samples, 1)))
+    new_journal.add_distances(new_distances)
+    new_journal.add_user_parameters(new_names_and_parameters)
+    new_journal.number_of_simulations.append(journal.number_of_simulations[-1])
+
+    return new_journal

--- a/sbibm/algorithms/abcpy/rejection_abc.py
+++ b/sbibm/algorithms/abcpy/rejection_abc.py
@@ -1,0 +1,124 @@
+from typing import Optional, Tuple
+import numpy as np
+import torch
+from abcpy.backends import BackendDummy
+from abcpy.inferences import RejectionABC
+from abcpy.statistics import Identity
+
+import sbibm
+from sbibm.algorithms.abcpy.abcpy_utils import ABCpyPrior, get_distance, ABCpySimulator, journal_cleanup_rejABC
+from sbibm.tasks.task import Task
+from sbibm.utils.io import save_tensor_to_csv
+
+
+def run(
+        task: Task,
+        num_samples: int,
+        num_simulations: int,
+        num_observation: Optional[int] = None,
+        observation: Optional[torch.Tensor] = None,
+        num_top_samples: Optional[int] = 100,
+        quantile: Optional[float] = None,
+        eps: Optional[float] = None,
+        distance: str = "l2",
+        save_distances: bool = False,
+        sass: bool = False,
+        sass_fraction: float = 0.5,
+        sass_feature_expansion_degree: int = 3,
+) -> Tuple[torch.Tensor, int, Optional[torch.Tensor]]:
+    """Runs REJ-ABC from `ABCpy`
+
+    For now, we do not include generating more than one simulation for parameter value; can do that in the future.
+
+    Moreover, we are not using a KDE on the ABC posterior samples in order to obtain a density estimate, as done in the
+    pyABC wrap; for this reason we are assuming here that num_samples is the same as num_simulations.
+
+    I believe however we are not returning the expected number of samples, as that would be num_samples, but instead we
+    take the given quantile of num_simulations.
+
+    We are also not doing SASS for now, and LRA after sampling.
+
+    Choose one of `num_top_samples`, `quantile`, `eps`. We are actually not using eps for now, as I don't know how to
+    combine that with the required simulation budget.
+
+    Args:
+        task: Task instance
+        num_samples: Number of samples to generate from posterior
+        num_simulations: Simulation budget
+        num_observation: Observation number to load, alternative to `observation`
+        observation: Observation, alternative to `num_observation`
+        num_top_samples: If given, will use `top=True` with num_top_samples
+        quantile: Quantile to use
+        eps: Epsilon threshold to use
+        distance: Distance to use; can be "l2" (Euclidean Distance), "log_reg" (LogReg) or "pen_log_reg" (PenLogReg)
+        save_distances: If True, stores distances of samples to disk
+        sass: If True, summary statistics are learned as in
+            Fearnhead & Prangle 2012.
+        sass_fraction: Fraction of simulation budget to use for sass.
+        sass_feature_expansion_degree: Degree of polynomial expansion of the summary
+            statistics.
+    Returns:
+        Samples from posterior, number of simulator calls, log probability of true params if computable
+    """
+    if sass:
+        raise NotImplementedError("SASS not yet implemented")
+    if eps is not None:
+        raise NotImplementedError
+
+    assert num_simulations == num_samples
+
+    assert not (num_observation is None and observation is None)
+    assert not (num_observation is not None and observation is not None)
+
+    assert not (num_top_samples is None and quantile is None and eps is None)
+
+    log = sbibm.get_logger(__name__)
+    log.info(f"Running REJ-ABC")
+
+    if observation is None:
+        observation = task.get_observation(num_observation)
+
+    if num_top_samples is not None and quantile is None:
+        if sass:
+            quantile = num_top_samples / (
+                    num_simulations - int(sass_fraction * num_simulations)
+            )
+        else:
+            quantile = num_top_samples / num_simulations
+
+    # use the dummy backend only (for now)
+    backend = BackendDummy()
+
+    # as Rejection ABC works by directly drawing until you get below some threshold -> here we set the threshold to
+    # very large value and then we select the best objects later.
+
+    statistics = Identity(degree=1, cross=True)  # we assume statistics are already computed inside the task
+    distance_calc = get_distance(distance, statistics)
+
+    # define prior and model from the task simulator:
+    parameters = ABCpyPrior(task)
+    model = ABCpySimulator([parameters], task, num_simulations=num_simulations)
+
+    # inference; not sure how to use random seed
+    sampler = RejectionABC(root_models=[model], distances=[distance_calc], backend=backend, seed=None)
+    # print("obs", [observation])
+    # print("obs", [np.array(observation)])
+    journal_standard_ABC = sampler.sample([[np.array(observation)]], n_samples=num_simulations,
+                                          n_samples_per_param=1, epsilon=10 ** 50)  # set epsilon to very large number
+    journal_standard_ABC_reduced = journal_cleanup_rejABC(journal_standard_ABC, percentile=quantile * 100)
+
+    assert journal_standard_ABC.number_of_simulations[-1] == num_simulations
+
+    if save_distances:
+        distances = torch.tensor(journal_standard_ABC_reduced.distances[-1])
+        save_tensor_to_csv("/home/lorenzo/Scrivania/OxWaSP/ABC-project/Code/sbibm/distances.csv", distances)
+
+    samples = torch.tensor(journal_standard_ABC_reduced.get_accepted_parameters()).squeeze()  # that should work
+
+    if num_observation is not None:
+        # true_parameters = task.get_true_parameters(num_observation=num_observation)
+        # log_prob_true_parameters = posterior.log_prob(true_parameters)
+        # we can't compute posterior probability with ABCpy
+        return samples, journal_standard_ABC.number_of_simulations[-1], None
+    else:
+        return samples, journal_standard_ABC.number_of_simulations[-1], None

--- a/try_ABCpy.py
+++ b/try_ABCpy.py
@@ -1,0 +1,32 @@
+import sbibm
+task_name = "gaussian_linear"
+task_name = "two_moons"
+
+task = sbibm.get_task(task_name)  # See sbibm.get_available_tasks() for all tasks
+prior = task.get_prior()
+simulator = task.get_simulator()
+observation = task.get_observation(num_observation=1)  # 10 per task
+
+# Alternatively, we can import existing algorithms, e.g:
+from sbibm.algorithms.abcpy.rejection_abc import run as rej_abc  # See help(rej_abc) for keywords
+num_samples = 10000
+posterior_samples, _, _ = rej_abc(task=task, num_samples=num_samples, num_observation=1, num_simulations=num_samples, quantile=0.03)
+# posterior_samples, _, _ = rej_abc(task=task, num_samples=num_samples, num_observation=1, num_simulations=num_samples, num_top_samples=100)
+
+print("Posterior samples shape", posterior_samples.shape)
+
+# Once we got samples from an approximate posterior, compare them to the reference:
+# from sbibm.metrics import c2st
+# reference_samples = task.get_reference_posterior_samples(num_observation=1)
+# c2st_accuracy = c2st(reference_samples, posterior_samples)
+
+# Visualise both posteriors:
+from sbibm.visualisation import fig_posterior
+fig = fig_posterior(task_name=task_name, observation=1, samples_tensor=posterior_samples, num_samples=100, prior=False)
+fig.show()
+# Note: Use fig.show() or fig.save() to show or save the figure
+
+# Get results from other algorithms for comparison:
+# from sbibm.visualisation import fig_metric
+# results_df = sbibm.get_results(dataset="main_paper.csv")
+# fig = fig_metric(results_df.query("task == 'two_moons'"), metric="C2ST")


### PR DESCRIPTION
Hello, 

I thought I'd open this pull request to keep track of my progress and ask for feedback (even if I don't think this is ready to merge yet). 

I've done my first attempt at wrapping ABCpy. For now I've wrapped the Rejection ABC algorithm (I know you've that already, but that was the easiest one to do). 

It seems to work (I've added a `try_ABCpy.py` file if you want to experiment with it), but I have made quite some simplifications as I did not know how to do some things. Precisely:
- It looks like you have two separate parameters: `num_simulations` which is the total number of simulations which you allow, and then `num_samples` which is the returned number of posterior samples; if I am not wrong, you generate those with KDE from the ABC samples (at least this is what happens in the pyABC wrap). In my wrap of ABCpy, I have for now run Rej-ABC for `num_simulations` times, and then simply returned as posterior samples the ones obtained when considering the quantile of distances defined by `quantile`, or the `num_top_samples` ones. I am therefore not returning the specified `num_samples`. Do you suggest using your KDE code in this case as well? I believe it should be easily doable, only did not know what was the precise aim of it. 
- In the pyABC wrap, you choose one of `num_top_samples`, `quantile`, `eps`. I have not yet used the `eps` one, but will add code for that soon.
- In ABCpy, we have the option of generating more than one simulation for parameter value and average the estimate of the distabce; I have not put that option for now, do you think that is useful?
- I've not yet added SASS option (even if that is implemented in ABCpy); also, we do not have postprocessing LRA in ABCpy.

Please let me know what you think of my attempt. 
