### PR TITLE
PyTorch 1.8 compatibility and KDE warnings

### DIFF
--- a/sbibm/algorithms/sbi/mcabc.py
+++ b/sbibm/algorithms/sbi/mcabc.py
@@ -105,7 +105,9 @@ def run(
         samples = posterior._samples
 
         log.info(
-            f"KDE on {samples.shape[0]} samples with bandwidth option {kde_bandwidth}"
+            f"""KDE on {samples.shape[0]} samples with bandwidth option {kde_bandwidth}.
+            Beware that KDE can give unreliable results when used with too few samples
+            and in high dimensions."""
         )
         kde = get_kde(samples, bandwidth=kde_bandwidth)
 

--- a/sbibm/algorithms/sbi/smcabc.py
+++ b/sbibm/algorithms/sbi/smcabc.py
@@ -42,7 +42,7 @@ def run(
 
     SMC-ABC supports two different ways of scheduling epsilon:
     1) Exponential decay: eps_t+1 = epsilon_decay * eps_t
-    2) Distance based decay: the new eps is determined from the "epsilon_decay" 
+    2) Distance based decay: the new eps is determined from the "epsilon_decay"
         quantile of the distances of the accepted simulations in the previous population. This is used if `distance_based_decay` is set to True.
 
     Args:
@@ -57,7 +57,7 @@ def run(
         epsilon_decay: Decay for epsilon; treated as quantile in case of distance based decay.
         distance_based_decay: Whether to determine new epsilon from quantile of
             distances of the previous population.
-        ess_min: Threshold for resampling a population if effective sampling size is 
+        ess_min: Threshold for resampling a population if effective sampling size is
             too small.
         initial_round_factor: Used to determine initial round size
         batch_size: Batch size for the simulator
@@ -140,7 +140,9 @@ def run(
 
     if save_summary:
         log.info("Saving smcabc summary to csv.")
-        pd.DataFrame.from_dict(summary,).to_csv("summary.csv", index=False)
+        pd.DataFrame.from_dict(
+            summary,
+        ).to_csv("summary.csv", index=False)
 
     assert simulator.num_simulations == num_simulations
 
@@ -148,7 +150,9 @@ def run(
         samples = posterior._samples
 
         log.info(
-            f"KDE on {samples.shape[0]} samples with bandwidth option {kde_bandwidth}"
+            f"""KDE on {samples.shape[0]} samples with bandwidth option {kde_bandwidth}.
+            Beware that KDE can give unreliable results when used with too few samples
+            and in high dimensions."""
         )
 
         kde = get_kde(

--- a/sbibm/algorithms/sbi/snle.py
+++ b/sbibm/algorithms/sbi/snle.py
@@ -87,8 +87,9 @@ def run(
     simulator = task.get_simulator(max_calls=num_simulations)
 
     transforms = task._get_transforms(automatic_transforms_enabled)["parameters"]
-    prior = wrap_prior_dist(prior, transforms)
-    simulator = wrap_simulator_fn(simulator, transforms)
+    if automatic_transforms_enabled:
+        prior = wrap_prior_dist(prior, transforms)
+        simulator = wrap_simulator_fn(simulator, transforms)
 
     density_estimator_fun = likelihood_nn(
         model=neural_net.lower(),
@@ -97,7 +98,8 @@ def run(
         z_score_theta=z_score_theta,
     )
     inference_method = inference.SNLE_A(
-        density_estimator=density_estimator_fun, prior=prior,
+        density_estimator=density_estimator_fun,
+        prior=prior,
     )
 
     posteriors = []

--- a/sbibm/algorithms/sbi/snpe.py
+++ b/sbibm/algorithms/sbi/snpe.py
@@ -78,8 +78,10 @@ def run(
     simulator = task.get_simulator(max_calls=num_simulations)
 
     transforms = task._get_transforms(automatic_transforms_enabled)["parameters"]
-    prior = wrap_prior_dist(prior, transforms)
-    simulator = wrap_simulator_fn(simulator, transforms)
+
+    if automatic_transforms_enabled:
+        prior = wrap_prior_dist(prior, transforms)
+        simulator = wrap_simulator_fn(simulator, transforms)
 
     density_estimator_fun = posterior_nn(
         model=neural_net.lower(),

--- a/sbibm/algorithms/sbi/snre.py
+++ b/sbibm/algorithms/sbi/snre.py
@@ -91,8 +91,9 @@ def run(
     simulator = task.get_simulator(max_calls=num_simulations)
 
     transforms = task._get_transforms(automatic_transforms_enabled)["parameters"]
-    prior = wrap_prior_dist(prior, transforms)
-    simulator = wrap_simulator_fn(simulator, transforms)
+    if automatic_transforms_enabled:
+        prior = wrap_prior_dist(prior, transforms)
+        simulator = wrap_simulator_fn(simulator, transforms)
 
     classifier = classifier_nn(
         model=neural_net.lower(),

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ REQUIRED = [
     "pandas>=1.0.0",
     "pyabc>=0.10.8",
     "pyabcranger>=0.0.48",
-    "sbi==0.14.2",
+    "sbi==0.15.1",
     "pyro-ppl",
     "scikit-learn",
     "torch>=1.5.1",
@@ -133,5 +133,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
-    cmdclass={"upload": UploadCommand,},
+    cmdclass={
+        "upload": UploadCommand,
+    },
 )


### PR DESCRIPTION
For context: This PR makes `sbibm` compatibe with the latest PyTorch version (1.8) necessary due to changes in their API of transformed distributions.

When using the identity transform in case of `automatic_transforms_enabled=False`, for `SNPE`, the support of the resulting `TransformedDistribution` becomes unbounded in `PyTorch`, even if the support of base distribution is bounded. This leads to wrong rejection sampling in sequential NPE with bounded support priors. 

The PR fixes this by not wrapping the prior as `TransformedDistribution` in the `run.py` script. 
(This has the additional advantage that the `prior` is not wrapped and will be recognised "as is" by `sbi`, which is required for running `SNPE` with mixture density networks.)

The PR additionally extends the info when using KDE with ABC methods, see #7 . 