### PR TITLE
Fix torch>=1.8 compatibility

### DIFF
--- a/sbibm/algorithms/pytorch/baseline_grid.py
+++ b/sbibm/algorithms/pytorch/baseline_grid.py
@@ -93,6 +93,7 @@ def run(
         observation=observation,
         implementation="experimental",
         posterior=True,
+        **kwargs,
     )
 
     total_evaluations = grid_flat.shape[0]
@@ -103,7 +104,7 @@ def run(
 
     log_probs = torch.empty([resolution for _ in range(dim_parameters)])
     for i in tqdm(range(num_batches)):
-        ix_from = i * num_batches
+        ix_from = i * batch_size
         ix_to = ix_from + batch_size
         if ix_to > total_evaluations:
             ix_to = total_evaluations
@@ -118,8 +119,7 @@ def run(
     indices = torch.arange(0, len(probs))
     idxs = choice(indices, num_samples, True, probs)
     samples = grid_flat[idxs, :]
-
-    num_unique_samples = len(torch.unique(samples))
+    num_unique_samples = len(torch.unique(samples, dim=0))
     log.info(f"Unique samples: {num_unique_samples}")
 
     toc = time.time()

--- a/sbibm/utils/kde.py
+++ b/sbibm/utils/kde.py
@@ -27,7 +27,7 @@ def get_kde(
         X: Samples
         bandwidth: Bandwidth method
         transform: Optional transform
-        sample_weight: Sample weights attached to the data 
+        sample_weight: Sample weights attached to the data
         verbose: Verbosity level
 
     References:
@@ -131,10 +131,7 @@ class KDEWrapper:
         log_probs = torch.from_numpy(
             self.kde.score_samples(parameters_unconstrained.numpy()).astype(np.float32)
         )
-        log_probs += torch.sum(
-            self.transform.log_abs_det_jacobian(
-                parameters_constrained, parameters_unconstrained
-            ),
-            axis=1,
+        log_probs += self.transform.log_abs_det_jacobian(
+            parameters_constrained, parameters_unconstrained
         )
         return log_probs

--- a/sbibm/utils/kde.py
+++ b/sbibm/utils/kde.py
@@ -5,6 +5,7 @@ import torch
 from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors import KernelDensity
 from torch import distributions as dist
+from sbibm.utils.torch import get_log_abs_det_jacobian
 
 transform_types = Optional[
     Union[
@@ -131,7 +132,7 @@ class KDEWrapper:
         log_probs = torch.from_numpy(
             self.kde.score_samples(parameters_unconstrained.numpy()).astype(np.float32)
         )
-        log_probs += self.transform.log_abs_det_jacobian(
-            parameters_constrained, parameters_unconstrained
+        log_probs += get_log_abs_det_jacobian(
+            self.transform, parameters_constrained, parameters_unconstrained
         )
         return log_probs

--- a/sbibm/utils/nflows.py
+++ b/sbibm/utils/nflows.py
@@ -17,7 +17,7 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from tqdm import tqdm  # noqa
 
-from sbibm.utils.torch import get_default_device
+from sbibm.utils.torch import get_default_device, get_log_abs_det_jacobian
 
 
 def get_flow(
@@ -331,8 +331,8 @@ class FlowWrapper:
         log_probs = self.flow.log_prob(parameters_unconstrained)
         # NOTE: Does not need sum over axis anymore, is now summed in torch:
         # https://pytorch.org/docs/stable/_modules/torch/distributions/transforms.html#Transform.log_abs_det_jacobian
-        log_probs += self.transform.log_abs_det_jacobian(
-            parameters_constrained, parameters_unconstrained
+        log_probs += get_log_abs_det_jacobian(
+            self.transform, parameters_constrained, parameters_unconstrained
         )
         return log_probs
 

--- a/sbibm/utils/nflows.py
+++ b/sbibm/utils/nflows.py
@@ -96,7 +96,12 @@ def get_flow(
             ]
         )
 
-        transform = transforms.CompositeTransform([standardizing_transform, transform,])
+        transform = transforms.CompositeTransform(
+            [
+                standardizing_transform,
+                transform,
+            ]
+        )
 
         distribution = distributions_.StandardNormal((features,))
         neural_net = flows.Flow(transform, distribution, embedding)
@@ -246,7 +251,10 @@ def train_flow(
         sampler=SubsetRandomSampler(val_indices),
     )
 
-    optimizer = optim.Adam(list(flow.parameters()), lr=learning_rate,)
+    optimizer = optim.Adam(
+        list(flow.parameters()),
+        lr=learning_rate,
+    )
     # Keep track of best_validation log_prob seen so far.
     best_validation_log_prob = -1e100
     # Keep track of number of epochs since last improvement.
@@ -329,11 +337,10 @@ class FlowWrapper:
     def log_prob(self, parameters_constrained):
         parameters_unconstrained = self.transform(parameters_constrained)
         log_probs = self.flow.log_prob(parameters_unconstrained)
-        log_probs += torch.sum(
-            self.transform.log_abs_det_jacobian(
-                parameters_constrained, parameters_unconstrained
-            ),
-            axis=1,
+        # NOTE: Does not need sum over axis anymore, is now summed in torch:
+        # https://pytorch.org/docs/stable/_modules/torch/distributions/transforms.html#Transform.log_abs_det_jacobian
+        log_probs += self.transform.log_abs_det_jacobian(
+            parameters_constrained, parameters_unconstrained
         )
         return log_probs
 

--- a/sbibm/utils/nflows.py
+++ b/sbibm/utils/nflows.py
@@ -329,8 +329,6 @@ class FlowWrapper:
     def log_prob(self, parameters_constrained):
         parameters_unconstrained = self.transform(parameters_constrained)
         log_probs = self.flow.log_prob(parameters_unconstrained)
-        # NOTE: Does not need sum over axis anymore, is now summed in torch:
-        # https://pytorch.org/docs/stable/_modules/torch/distributions/transforms.html#Transform.log_abs_det_jacobian
         log_probs += get_log_abs_det_jacobian(
             self.transform, parameters_constrained, parameters_unconstrained
         )

--- a/sbibm/utils/nflows.py
+++ b/sbibm/utils/nflows.py
@@ -96,12 +96,7 @@ def get_flow(
             ]
         )
 
-        transform = transforms.CompositeTransform(
-            [
-                standardizing_transform,
-                transform,
-            ]
-        )
+        transform = transforms.CompositeTransform([standardizing_transform, transform])
 
         distribution = distributions_.StandardNormal((features,))
         neural_net = flows.Flow(transform, distribution, embedding)
@@ -251,10 +246,7 @@ def train_flow(
         sampler=SubsetRandomSampler(val_indices),
     )
 
-    optimizer = optim.Adam(
-        list(flow.parameters()),
-        lr=learning_rate,
-    )
+    optimizer = optim.Adam(list(flow.parameters()), lr=learning_rate)
     # Keep track of best_validation log_prob seen so far.
     best_validation_log_prob = -1e100
     # Keep track of number of epochs since last improvement.

--- a/sbibm/utils/pyro.py
+++ b/sbibm/utils/pyro.py
@@ -161,9 +161,9 @@ def get_log_prob_grad_fn(
     """
     Given a Python callable with Pyro primitives, generates the following model-specific
     functions:
-    - a log prob grad function whose input are parameters and whose 
+    - a log prob grad function whose input are parameters and whose
       output is the grd of log prob of the model wrt parameters
-    - transforms to transform latent sites of `model` to 
+    - transforms to transform latent sites of `model` to
       unconstrained space
 
     Args:
@@ -207,9 +207,7 @@ class _LPMaker:
         )
         log_joint = self.trace_prob_evaluator.log_prob(model_trace)
         for name, t in self.transforms.items():
-            log_joint = log_joint - torch.sum(
-                t.log_abs_det_jacobian(params_constrained[name], params[name])
-            )
+            log_joint -= t.log_abs_det_jacobian(params_constrained[name], params[name])
         return log_joint
 
     def _lp_fn_jit(self, skip_jit_warnings, jit_options, params):
@@ -252,7 +250,7 @@ def make_log_prob_grad_fn(log_prob_fn):
     Args:
         log_prob_fn: python callable that takes in a dictionary of parameters
         and returns the log prob.
-    
+
     Returns:
         `log_prob_grad_fn`
 

--- a/sbibm/utils/pyro.py
+++ b/sbibm/utils/pyro.py
@@ -19,6 +19,8 @@ from pyro.util import check_site_shape, ignore_jit_warnings
 from torch.autograd import grad
 from torch.distributions import biject_to
 
+from sbibm.utils.torch import get_log_abs_det_jacobian
+
 
 def get_log_prob_fn(
     model,
@@ -207,7 +209,9 @@ class _LPMaker:
         )
         log_joint = self.trace_prob_evaluator.log_prob(model_trace)
         for name, t in self.transforms.items():
-            log_joint -= t.log_abs_det_jacobian(params_constrained[name], params[name])
+            log_joint -= get_log_abs_det_jacobian(
+                t, params_constrained[name], params[name]
+            )
         return log_joint
 
     def _lp_fn_jit(self, skip_jit_warnings, jit_options, params):

--- a/tests/utils/test_pyro.py
+++ b/tests/utils/test_pyro.py
@@ -130,10 +130,8 @@ def test_transforms():
 
     # through change of variables, we can recover the original log prob
     # ladj(x,y) -> log |dy/dx| -> ladj(untransformed, transformed)
-    log_prob_3 = log_prob_2 + torch.sum(
-        transforms.log_abs_det_jacobian(
-            parameters_constrained, parameters_unconstrained
-        )
+    log_prob_3 = log_prob_2 + transforms.log_abs_det_jacobian(
+        parameters_constrained, parameters_unconstrained
     )
 
     assert torch.allclose(log_prob_1, log_prob_3)

--- a/tests/utils/test_pyro.py
+++ b/tests/utils/test_pyro.py
@@ -3,6 +3,8 @@ import torch
 
 import sbibm
 
+from sbibm.utils.torch import get_log_abs_det_jacobian
+
 
 @pytest.mark.parametrize(
     "task_name,jit_compile,batch_size,implementation,posterior",
@@ -130,8 +132,8 @@ def test_transforms():
 
     # through change of variables, we can recover the original log prob
     # ladj(x,y) -> log |dy/dx| -> ladj(untransformed, transformed)
-    log_prob_3 = log_prob_2 + transforms.log_abs_det_jacobian(
-        parameters_constrained, parameters_unconstrained
+    log_prob_3 = log_prob_2 + get_log_abs_det_jacobian(
+        transforms, parameters_constrained, parameters_unconstrained
     )
 
     assert torch.allclose(log_prob_1, log_prob_3)


### PR DESCRIPTION
fixes bugs introduced by the upgrade to `torch=1.8`. 

In particular, since the new `torch`, `log_abs_det_jac` already takes the sum over the event dimension so that one does not have to do it manually anymore:
https://pytorch.org/docs/stable/_modules/torch/distributions/transforms.html#Transform.log_abs_det_jacobian
