### PR TITLE
Add metrics for posterior mean and variance

### DIFF
--- a/sbibm/metrics/__init__.py
+++ b/sbibm/metrics/__init__.py
@@ -1,4 +1,5 @@
 from sbibm.metrics.c2st import c2st  # noqa: F401
 from sbibm.metrics.ksd import ksd  # noqa: F401
 from sbibm.metrics.mmd import mmd  # noqa: F401
+from sbibm.metrics.moments import posterior_mean_error, posterior_variance_ratio
 from sbibm.metrics.ppc import median_distance  # noqa: F401

--- a/sbibm/metrics/moments.py
+++ b/sbibm/metrics/moments.py
@@ -1,0 +1,40 @@
+import torch
+
+
+def posterior_mean_error(
+    samples: torch.Tensor,
+    reference_posterior_samples: torch.Tensor,
+) -> torch.Tensor:
+    """Return absolute error between posterior means normalized by true std.
+    Args:
+        samples: Approximate samples
+        reference_posterior_samples: Reference posterior samples
+    Returns:
+        absolute error in posterior mean, normalized by std, averaged over dimensions.
+    """
+    assert samples.ndim == 2
+    assert reference_posterior_samples.ndim == 2
+    abs_error_per_dim = (
+        samples.mean(0) - reference_posterior_samples.mean(0)
+    ) / reference_posterior_samples.std(0)
+
+    return torch.mean(abs_error_per_dim)
+
+
+def posterior_variance_ratio(
+    samples: torch.Tensor,
+    reference_posterior_samples: torch.Tensor,
+) -> torch.Tensor:
+    """Return ratio of approximate and true variance, averaged over dimensions.
+    Args:
+        samples: Approximate samples
+        reference_posterior_samples: Reference posterior samples
+    Returns:
+        ratio of approximate and true posterior variance, averaged over dimensions.
+    """
+    assert samples.ndim == 2
+    assert reference_posterior_samples.ndim == 2
+
+    ratio_per_dim = samples.var(0) / reference_posterior_samples.var(0)
+
+    return torch.mean(ratio_per_dim)

--- a/tests/metrics/test_moments.py
+++ b/tests/metrics/test_moments.py
@@ -1,0 +1,18 @@
+import torch
+
+from sbibm.metrics import posterior_mean_error, posterior_variance_ratio
+
+
+def test_posterior_moments_metrics():
+
+    num_dim = 3
+    num_samples = 10000
+    dist = torch.distributions.MultivariateNormal(torch.zeros(num_dim), torch.eye(num_dim))
+
+    mean_err = posterior_mean_error(dist.sample((num_samples,)), dist.sample((num_samples,)))
+
+    assert torch.isclose(mean_err, torch.tensor(0.0), atol=3e-2)
+
+    variance_ratio = posterior_variance_ratio(dist.sample((num_samples,)), dist.sample((num_samples,)))
+
+    assert torch.isclose(variance_ratio, torch.tensor(1.0), atol=1e-1)


### PR DESCRIPTION
add two new metrics: 
- absolute mean error normalised by std
- ratio of approximate and true variance
both calculated on the marginals and averaged over dimensions. 