### PR TITLE
Squeeze parameters over batches before log_prob

### DIFF
--- a/sbibm/algorithms/sbi/mcabc.py
+++ b/sbibm/algorithms/sbi/mcabc.py
@@ -117,7 +117,7 @@ def run(
 
     if num_observation is not None:
         true_parameters = task.get_true_parameters(num_observation=num_observation)
-        log_prob_true_parameters = posterior.log_prob(true_parameters)
+        log_prob_true_parameters = posterior.log_prob(true_parameters.squeeze())
         return samples, simulator.num_simulations, log_prob_true_parameters
     else:
         return samples, simulator.num_simulations, None

--- a/sbibm/algorithms/sbi/smcabc.py
+++ b/sbibm/algorithms/sbi/smcabc.py
@@ -166,7 +166,7 @@ def run(
 
     if num_observation is not None:
         true_parameters = task.get_true_parameters(num_observation=num_observation)
-        log_prob_true_parameters = posterior.log_prob(true_parameters)
+        log_prob_true_parameters = posterior.log_prob(true_parameters.squeeze())
         return samples, simulator.num_simulations, log_prob_true_parameters
     else:
         return samples, simulator.num_simulations, None


### PR DESCRIPTION
Resolves #12

As mentioned in the issue, squeeze parameters over the singleton batch dimension prior to taking `log_prob`s. This addresses the more aggressive shape validation introduced in PyTorch 1.8.0.