### PR TITLE
Refactor for next `sbi` version

### DIFF
--- a/sbibm/algorithms/pyabc/smcabc.py
+++ b/sbibm/algorithms/pyabc/smcabc.py
@@ -255,7 +255,7 @@ def run(
         kde = get_kde(
             samples,
             bandwidth=kde_bandwidth,
-            sample_weight=weights if kde_sample_weights else None,
+            sample_weights=weights if kde_sample_weights else None,
         )
         samples = kde.sample(num_samples)
     else:

--- a/sbibm/algorithms/pytorch/utils/proposal.py
+++ b/sbibm/algorithms/pytorch/utils/proposal.py
@@ -52,7 +52,7 @@ def get_proposal(
         )
 
     elif density_estimator == "kde":
-        density_estimator_ = get_kde(X=samples, transform=transform, **kwargs)
+        density_estimator_ = get_kde(samples=samples, transform=transform, **kwargs)
 
     else:
         raise NotImplementedError

--- a/sbibm/algorithms/sbi/mcabc.py
+++ b/sbibm/algorithms/sbi/mcabc.py
@@ -1,4 +1,5 @@
 from typing import Optional, Tuple
+import pandas as pd
 
 import torch
 from sbi.inference import MCABC
@@ -7,7 +8,6 @@ import sbibm
 from sbibm.tasks.task import Task
 from sbibm.utils.io import save_tensor_to_csv
 from sbibm.utils.kde import get_kde
-from .utils import get_sass_transform, run_lra
 
 
 def run(
@@ -117,7 +117,7 @@ def run(
 
     if num_observation is not None:
         true_parameters = task.get_true_parameters(num_observation=num_observation)
-        log_prob_true_parameters = posterior.log_prob(true_parameters)
+        log_prob_true_parameters = posterior.log_prob(true_parameters.squeeze())
         return samples, simulator.num_simulations, log_prob_true_parameters
     else:
         return samples, simulator.num_simulations, None

--- a/sbibm/algorithms/sbi/smcabc.py
+++ b/sbibm/algorithms/sbi/smcabc.py
@@ -158,7 +158,7 @@ def run(
         kde = get_kde(
             samples,
             bandwidth=kde_bandwidth,
-            sample_weight=posterior._log_weights.exp() if kde_sample_weights else None,
+            sample_weights=posterior._log_weights.exp() if kde_sample_weights else None,
         )
         samples = kde.sample(num_samples)
     else:


### PR DESCRIPTION
this ports refactor of `kde` done `sbi` to `sbibm` and adapt the abc-methods in `sbibm`. 

In `sbibm` we currently depend on `sbi>=0.14.2.`. However, with the changes to the `abc` methods it would make sense to depend on the new release that returns the `kde` or just the particles. 

Additionally, there was a fix to `smcabc` to prevent `out of support` error due to the update to `torch>1.5.1`, see [this commit](https://github.com/mackelab/sbi/commit/b1956e50167145cd1cb268d6ba6f22f02c40e1cc). With `sbi=0.14.2` this currently fails all `smcabc` runs with priors with bounded support. 