### PR TITLE
Getting rid of need for `get_log_abs_det_jacobian` function

### DIFF
--- a/sbibm/utils/kde.py
+++ b/sbibm/utils/kde.py
@@ -5,7 +5,6 @@ import torch
 from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors import KernelDensity
 from torch import distributions as dist
-from sbibm.utils.torch import get_log_abs_det_jacobian
 
 transform_types = Optional[
     Union[
@@ -132,7 +131,8 @@ class KDEWrapper:
         log_probs = torch.from_numpy(
             self.kde.score_samples(parameters_unconstrained.numpy()).astype(np.float32)
         )
-        log_probs += get_log_abs_det_jacobian(
-            self.transform, parameters_constrained, parameters_unconstrained
+
+        log_probs += self.transform.log_abs_det_jacobian(
+            parameters_constrained, parameters_unconstrained
         )
         return log_probs

--- a/sbibm/utils/nflows.py
+++ b/sbibm/utils/nflows.py
@@ -17,7 +17,7 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from tqdm import tqdm  # noqa
 
-from sbibm.utils.torch import get_default_device, get_log_abs_det_jacobian
+from sbibm.utils.torch import get_default_device
 
 
 def get_flow(
@@ -329,8 +329,8 @@ class FlowWrapper:
     def log_prob(self, parameters_constrained):
         parameters_unconstrained = self.transform(parameters_constrained)
         log_probs = self.flow.log_prob(parameters_unconstrained)
-        log_probs += get_log_abs_det_jacobian(
-            self.transform, parameters_constrained, parameters_unconstrained
+        log_probs += self.transform.log_abs_det_jacobian(
+            parameters_constrained, parameters_unconstrained
         )
         return log_probs
 

--- a/sbibm/utils/pyro.py
+++ b/sbibm/utils/pyro.py
@@ -20,8 +20,6 @@ from torch.autograd import grad
 from torch.distributions import biject_to
 from torch.distributions.transforms import IndependentTransform
 
-from sbibm.utils.torch import get_log_abs_det_jacobian
-
 
 def get_log_prob_fn(
     model,
@@ -215,9 +213,10 @@ class _LPMaker:
         )
         log_joint = self.trace_prob_evaluator.log_prob(model_trace)
         for name, t in self.transforms.items():
-            log_joint -= get_log_abs_det_jacobian(
-                t, params_constrained[name], params[name]
-            )
+            log_joint -= t.log_abs_det_jacobian(
+                params_constrained[name], params[name]
+            ).squeeze()
+
         return log_joint
 
     def _lp_fn_jit(self, skip_jit_warnings, jit_options, params):

--- a/sbibm/utils/pyro.py
+++ b/sbibm/utils/pyro.py
@@ -18,6 +18,7 @@ from pyro.poutine.subsample_messenger import _Subsample
 from pyro.util import check_site_shape, ignore_jit_warnings
 from torch.autograd import grad
 from torch.distributions import biject_to
+from torch.distributions.transforms import IndependentTransform
 
 from sbibm.utils.torch import get_log_abs_det_jacobian
 
@@ -100,6 +101,11 @@ def get_log_prob_fn(
             transforms[name] = biject_to(fn.support).inv
         else:
             transforms[name] = dist.transforms.identity_transform
+
+        if not isinstance(transforms[name], IndependentTransform):
+            transforms[name] = IndependentTransform(
+                transforms[name], reinterpreted_batch_ndims=1
+            )
 
     if implementation == "pyro":
         trace_prob_evaluator = TraceEinsumEvaluator(

--- a/sbibm/utils/torch.py
+++ b/sbibm/utils/torch.py
@@ -81,7 +81,8 @@ def get_log_abs_det_jacobian(
 ) -> torch.Tensor:
     """Return log_abs_det_jacobian over batch of parameters.
 
-    Take sum over second dimension if needed, e.g., when torch < 1.8 is used.
+    Take sum over event dimension if needed, e.g., when torch < 1.8 is used
+    or the transform is defined to not sum over event dimension.
 
     Args:
         transform: transform applied to the parameters
@@ -98,12 +99,11 @@ def get_log_abs_det_jacobian(
         parameters_constrained, parameters_unconstrained
     )
 
-    # For torch < 1.8 log_abs_det_jacobian is returned for each dimension.
     if vals.ndim > 1 and vals.shape[1] == dim_parameters:
-        vals = vals.sum(-1)
+        vals = vals.sum(1)
 
     assert (
-        vals.numel == batch_size
+        vals.numel() == batch_size
     ), "Mismatch in batch size, took sum over whole batch?"
 
     return vals

--- a/sbibm/utils/torch.py
+++ b/sbibm/utils/torch.py
@@ -72,38 +72,3 @@ def choice_numpy(
     samples = np.random.choice(a, num_samples, replace, p)
 
     return torch.as_tensor(samples, dtype=torch.float32)
-
-
-def get_log_abs_det_jacobian(
-    transform,
-    parameters_constrained: torch.Tensor,
-    parameters_unconstrained: torch.Tensor,
-) -> torch.Tensor:
-    """Return log_abs_det_jacobian over batch of parameters.
-
-    Take sum over event dimension if needed, e.g., when torch < 1.8 is used
-    or the transform is defined to not sum over event dimension.
-
-    Args:
-        transform: transform applied to the parameters
-        parameters_constrained:
-        parameters_unconstrained:
-
-    Returns:
-        torch.Tensor: log_abs_det_jacobian value for each batch entry.
-    """
-
-    batch_size, dim_parameters = parameters_constrained.shape
-
-    vals = transform.log_abs_det_jacobian(
-        parameters_constrained, parameters_unconstrained
-    )
-
-    if vals.ndim > 1 and vals.shape[1] == dim_parameters:
-        vals = vals.sum(1)
-
-    assert (
-        vals.numel() == batch_size
-    ), "Mismatch in batch size, took sum over whole batch?"
-
-    return vals

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIRED = [
     "sbi>=0.14.2",
     "pyro-ppl",
     "scikit-learn",
-    "torch>=1.5.1",
+    "torch>=1.8.0",
     "tqdm",
 ]
 


### PR DESCRIPTION
Long story short, this PR proposes a fix for the problem below by constructing all transforms such that the sum over the second dimension of the parameters `Tensor` passed to the `ladj` method. 

At the moment we have a helper function `get_log_abs_det_jacobian` (`ladj`) to make sure the `ladj` is returned summed over the parameter dimension. I looked into this a bit and understood why sometimes the sum is performed and sometimes not. 

The "raw" transforms from `torch.distributions.transforms` assume `event_dim=0` when initialised, so the transforms constructed here:
https://github.com/sbi-benchmark/sbibm/blob/89755d2785c2e79ab971341fb92d491e7c20a693/sbibm/utils/pyro.py#L99-L102
will all have `event_dim=0`. 
Thus, given a parameter with shape `(batch_size, dim_parameters)`, accumulating the `ladj` to get a transform-corrected `log_prob` here:
https://github.com/sbi-benchmark/sbibm/blob/89755d2785c2e79ab971341fb92d491e7c20a693/sbibm/utils/pyro.py#L211-L214
would result in a `ladj` shape of `(batch_size, dim_parameters)` instead of `(batch_size, )` (unless we use the `get_log_abs_det_jacobian` as we do it currently). 

But I think there is a cleaner solution. We noticed before that in some cases the sum over the second dimension is indeed calculated. This is the case when the transform is defined as an [`IndependentTransform`](https://pytorch.org/docs/stable/_modules/torch/distributions/transforms.html#IndependentTransform) with `reinterpreted_batch_ndims=1`, and this happens automatically when calling `biject_to` on a `BoxUniform` prior because this prior has reinterpreted batch dims already. 


With this fix we would not need `get_log_abs_det_jacobian` anymore. However, we first have to check it is bullet proof, e.g., what happens if the `prior` has more than two dimensions, is this case even allowed in `sbibm`?