### PR TITLE
Test for valid use of (S)NPE API

### DIFF
--- a/tests/algorithms/sbi/test_snpe_posterior.py
+++ b/tests/algorithms/sbi/test_snpe_posterior.py
@@ -30,6 +30,7 @@ def test_npe_posterior(
         num_samples=num_samples,
         num_rounds=1,
         neural_net="mdn",
+        max_num_epochs=30,
     )
 
     reference_samples = task.get_reference_posterior_samples(

--- a/tests/algorithms/test_baseline_posterior.py
+++ b/tests/algorithms/test_baseline_posterior.py
@@ -1,5 +1,3 @@
-import random
-
 import pytest
 import torch
 
@@ -17,7 +15,7 @@ from sbibm.metrics.c2st import c2st
             "gaussian_linear_uniform",
             "slcp",
         ]
-        for num_observation in range(1, 11)
+        for num_observation in [1, 2]
     ],
 )
 def test_posterior(

--- a/tests/algorithms/test_baseline_posterior.py
+++ b/tests/algorithms/test_baseline_posterior.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 import torch
 

--- a/tests/algorithms/test_snpe_posterior.py
+++ b/tests/algorithms/test_snpe_posterior.py
@@ -14,13 +14,12 @@ from sbibm.metrics.c2st import c2st
         for task_name in [
             "gaussian_linear",
             "gaussian_linear_uniform",
-            "slcp",
         ]
         for num_observation in [1, 3]
     ],
 )
 def test_npe_posterior(
-    task_name, num_observation, num_simulations=2_500, num_samples=50
+    task_name, num_observation, num_simulations=2_000, num_samples=100
 ):
     task = sbibm.get_task(task_name)
 
@@ -45,3 +44,4 @@ def test_npe_posterior(
 
     assert acc > 0.5
     assert acc < 1.0
+    assert acc > 0.6

--- a/tests/algorithms/test_snpe_posterior.py
+++ b/tests/algorithms/test_snpe_posterior.py
@@ -1,38 +1,47 @@
 import pytest
 import torch
-import random
 
 import sbibm
 from sbibm.algorithms.sbi.snpe import run as run_posterior
 from sbibm.metrics.c2st import c2st
 
-#a fast test
+
+# a fast test
 @pytest.mark.parametrize(
     "task_name,num_observation",
     [
         (task_name, num_observation)
-        for task_name in ["gaussian_linear", "slcp",]
-        for num_observation in random.sample(range(1, 11), 2)
+        for task_name in [
+            "gaussian_linear",
+            "gaussian_linear_uniform",
+            "slcp",
+        ]
+        for num_observation in [1, 3]
     ],
 )
 def test_npe_posterior(
-    task_name, num_observation, num_simulations=1_000, num_samples=100
+    task_name, num_observation, num_simulations=2_500, num_samples=50
 ):
     task = sbibm.get_task(task_name)
 
-    samples = run_posterior(
+    predicted, _, _ = run_posterior(
         task=task,
         num_observation=num_observation,
         num_simulations=num_simulations,
         num_samples=num_samples,
         num_rounds=1,
-        neural_net="mdn" #fast test
+        neural_net="mdn",
     )
 
     reference_samples = task.get_reference_posterior_samples(
         num_observation=num_observation
     )
 
-    acc = c2st(samples, reference_samples[:num_samples, :])
+    expected = reference_samples[:num_samples, :]
 
-    assert torch.abs(acc - 0.5) < 0.025
+    assert expected.shape == predicted.shape
+
+    acc = c2st(predicted, expected)
+
+    assert acc > 0.5
+    assert acc < 1.0

--- a/tests/algorithms/test_snpe_posterior.py
+++ b/tests/algorithms/test_snpe_posterior.py
@@ -1,0 +1,38 @@
+import pytest
+import torch
+import random
+
+import sbibm
+from sbibm.algorithms.sbi.snpe import run as run_posterior
+from sbibm.metrics.c2st import c2st
+
+#a fast test
+@pytest.mark.parametrize(
+    "task_name,num_observation",
+    [
+        (task_name, num_observation)
+        for task_name in ["gaussian_linear", "slcp",]
+        for num_observation in random.sample(range(1, 11), 2)
+    ],
+)
+def test_npe_posterior(
+    task_name, num_observation, num_simulations=1_000, num_samples=100
+):
+    task = sbibm.get_task(task_name)
+
+    samples = run_posterior(
+        task=task,
+        num_observation=num_observation,
+        num_simulations=num_simulations,
+        num_samples=num_samples,
+        num_rounds=1,
+        neural_net="mdn" #fast test
+    )
+
+    reference_samples = task.get_reference_posterior_samples(
+        num_observation=num_observation
+    )
+
+    acc = c2st(samples, reference_samples[:num_samples, :])
+
+    assert torch.abs(acc - 0.5) < 0.025


### PR DESCRIPTION
This PR attempts a solution to #23 without (yet) introducing test categories a la `@pytest.mark.slow` (see https://github.com/mackelab/sbi/blob/86256e02c1080965795e65062c4ab9d3a19015d2/tests/linearGaussian_snpe_test.py#L196)