### PR TITLE
Adapt usage of log_abs_det_jacobian for torch>=1.8

### DIFF
--- a/sbibm/tasks/task.py
+++ b/sbibm/tasks/task.py
@@ -194,7 +194,7 @@ class Task:
                     log_probs.append(
                         log_prob_fn({"parameters": parameters[i, :].reshape(1, -1)})
                     )
-                return torch.stack(log_probs)
+                return torch.cat(log_probs)
 
         def log_prob_experimental(parameters):
             return log_prob_fn({"parameters": parameters})

--- a/sbibm/utils/kde.py
+++ b/sbibm/utils/kde.py
@@ -6,7 +6,6 @@ from sklearn.model_selection import GridSearchCV
 from sklearn.neighbors import KernelDensity
 from torch import distributions as dist
 
-from sbibm.utils.torch import get_log_abs_det_jacobian
 
 transform_types = Optional[
     Union[
@@ -133,7 +132,7 @@ class KDEWrapper:
         log_probs = torch.from_numpy(
             self.kde.score_samples(parameters_unconstrained.numpy()).astype(np.float32)
         )
-        log_probs += get_log_abs_det_jacobian(
-            self.transform, parameters_constrained, parameters_unconstrained
+        log_probs += self.transform.log_abs_det_jacobian(
+            parameters_constrained, parameters_unconstrained
         )
         return log_probs

--- a/sbibm/utils/nflows.py
+++ b/sbibm/utils/nflows.py
@@ -17,7 +17,7 @@ from torch.utils import data
 from torch.utils.data.sampler import SubsetRandomSampler
 from tqdm import tqdm  # noqa
 
-from sbibm.utils.torch import get_default_device, get_log_abs_det_jacobian
+from sbibm.utils.torch import get_default_device
 
 
 def get_flow(
@@ -329,8 +329,8 @@ class FlowWrapper:
     def log_prob(self, parameters_constrained):
         parameters_unconstrained = self.transform(parameters_constrained)
         log_probs = self.flow.log_prob(parameters_unconstrained)
-        log_probs += get_log_abs_det_jacobian(
-            self.transform, parameters_constrained, parameters_unconstrained
+        log_probs += self.transform.log_abs_det_jacobian(
+            parameters_constrained, parameters_unconstrained
         )
         return log_probs
 

--- a/sbibm/utils/torch.py
+++ b/sbibm/utils/torch.py
@@ -72,38 +72,3 @@ def choice_numpy(
     samples = np.random.choice(a, num_samples, replace, p)
 
     return torch.as_tensor(samples, dtype=torch.float32)
-
-
-def get_log_abs_det_jacobian(
-    transform,
-    parameters_constrained: torch.Tensor,
-    parameters_unconstrained: torch.Tensor,
-) -> torch.Tensor:
-    """Return log_abs_det_jacobian over batch of parameters.
-
-    Take sum over second dimension if needed, e.g., when torch < 1.8 is used.
-
-    Args:
-        transform: transform applied to the parameters
-        parameters_constrained:
-        parameters_unconstrained:
-
-    Returns:
-        torch.Tensor: log_abs_det_jacobian value for each batch entry.
-    """
-
-    batch_size, dim_parameters = parameters_constrained.shape
-
-    vals = transform.log_abs_det_jacobian(
-        parameters_constrained, parameters_unconstrained
-    )
-
-    # For torch < 1.8 log_abs_det_jacobian is returned for each dimension.
-    if vals.ndim > 1 and vals.shape[1] == dim_parameters:
-        vals = vals.sum(-1)
-
-    assert (
-        vals.numel == batch_size
-    ), "Mismatch in batch size, took sum over whole batch?"
-
-    return vals

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIRED = [
     "sbi>=0.14.2",
     "pyro-ppl",
     "scikit-learn",
-    "torch>=1.5.1",
+    "torch>=1.8.0",
     "tqdm",
 ]
 

--- a/tests/utils/test_pyro.py
+++ b/tests/utils/test_pyro.py
@@ -2,7 +2,6 @@ import pytest
 import torch
 
 import sbibm
-from sbibm.utils.torch import get_log_abs_det_jacobian
 
 
 @pytest.mark.parametrize(
@@ -107,8 +106,12 @@ def test_log_prob_grad_fn(jit_compile, batch_size, implementation):
     assert torch.allclose(grads, analytical_grad)
 
 
-def test_transforms():
-    task = sbibm.get_task("gaussian_linear_uniform")
+# Test with tasks with different parameter dimensions and bounded support.
+@pytest.mark.parametrize(
+     "task_name", ["gaussian_linear_uniform", "gaussian_linear", "gaussian_mixture"]
+     )
+def test_transforms(task_name):
+    task = sbibm.get_task(task_name)
 
     observation = task.get_observation(num_observation=1)
     true_parameters = task.get_true_parameters(num_observation=1)
@@ -131,8 +134,8 @@ def test_transforms():
 
     # through change of variables, we can recover the original log prob
     # ladj(x,y) -> log |dy/dx| -> ladj(untransformed, transformed)
-    log_prob_3 = log_prob_2 + get_log_abs_det_jacobian(
-        transforms, parameters_constrained, parameters_unconstrained
+    log_prob_3 = log_prob_2 + transforms.log_abs_det_jacobian(
+        parameters_constrained, parameters_unconstrained
     )
 
     assert torch.allclose(log_prob_1, log_prob_3)


### PR DESCRIPTION
The dependence on torch 1.8 makes sense because the current `sbi` version, which we want to use, depends on it. 

With this change we get rid of the helper function `get_log_abs_det_jacobian` that was distinguishing between the behavior before and after torch 1.8 and was doing the summation explicitly.


Details:
- with the dependence on `torch>=1.8` the output of `log_prob` and `log_abs_det_jacobian` changes: when the input has several parameter dimensions the output will keep those dimensions and we would have to sum over them by hand to get the joint log_prob over parameter dimensions.
- this can be prevented by "reinterpreting" them as batch dimensions. 
-  for transforms this works via the `IndependentTransform` as a wrapper

See also #15 