### PR TITLE
No default validation of prior args

### DIFF
--- a/sbibm/tasks/bernoulli_glm/task.py
+++ b/sbibm/tasks/bernoulli_glm/task.py
@@ -57,6 +57,7 @@ class BernoulliGLM(Task):
 
         self.prior_params = {"loc": torch.zeros((M + 1,)), "precision_matrix": Binv}
         self.prior_dist = pdist.MultivariateNormal(**self.prior_params)
+        self.prior_dist.set_default_validate_args(False)
 
     def get_prior(self) -> Callable:
         def prior(num_samples=1):

--- a/sbibm/tasks/gaussian_linear/task.py
+++ b/sbibm/tasks/gaussian_linear/task.py
@@ -42,6 +42,7 @@ class GaussianLinear(Task):
         }
 
         self.prior_dist = pdist.MultivariateNormal(**self.prior_params)
+        self.prior_dist.set_default_validate_args(False)
 
         self.simulator_params = {
             "precision_matrix": torch.inverse(

--- a/sbibm/tasks/gaussian_linear_uniform/task.py
+++ b/sbibm/tasks/gaussian_linear_uniform/task.py
@@ -42,6 +42,7 @@ class GaussianLinearUniform(Task):
         }
 
         self.prior_dist = pdist.Uniform(**self.prior_params).to_event(1)
+        self.prior_dist.set_default_validate_args(False)
 
         self.simulator_params = {
             "precision_matrix": torch.inverse(

--- a/sbibm/tasks/gaussian_mixture/task.py
+++ b/sbibm/tasks/gaussian_mixture/task.py
@@ -42,6 +42,7 @@ class GaussianMixture(Task):
         }
 
         self.prior_dist = pdist.Uniform(**self.prior_params).to_event(1)
+        self.prior_dist.set_default_validate_args(False)
 
         self.simulator_params = {
             "mixture_locs_factor": torch.tensor([1.0, 1.0]),

--- a/sbibm/tasks/lotka_volterra/task.py
+++ b/sbibm/tasks/lotka_volterra/task.py
@@ -81,6 +81,7 @@ class LotkaVolterra(Task):
             "scale": torch.tensor([sigma_p, sigma_p, sigma_p, sigma_p]),
         }
         self.prior_dist = pdist.LogNormal(**self.prior_params).to_event(1)
+        self.prior_dist.set_default_validate_args(False)
 
         self.u0 = torch.tensor([30.0, 1.0])
         self.tspan = torch.tensor([0.0, days])

--- a/sbibm/tasks/sir/task.py
+++ b/sbibm/tasks/sir/task.py
@@ -85,6 +85,7 @@ class SIR(Task):
             "scale": torch.tensor([0.5, 0.2]),
         }
         self.prior_dist = pdist.LogNormal(**self.prior_params).to_event(1)
+        self.prior_dist.set_default_validate_args(False)
 
         self.u0 = torch.tensor([N - I0 - R0, I0, R0])
         self.tspan = torch.tensor([0.0, days])

--- a/sbibm/tasks/slcp/task.py
+++ b/sbibm/tasks/slcp/task.py
@@ -58,6 +58,7 @@ class SLCP(Task):
             "high": torch.tensor([+3.0 for _ in range(self.dim_parameters)]),
         }
         self.prior_dist = pdist.Uniform(**self.prior_params).to_event(1)
+        self.prior_dist.set_default_validate_args(False)
 
     def get_prior(self) -> Callable:
         def prior(num_samples=1):

--- a/sbibm/tasks/two_moons/task.py
+++ b/sbibm/tasks/two_moons/task.py
@@ -50,6 +50,7 @@ class TwoMoons(Task):
             "high": +prior_bound * torch.ones((self.dim_parameters,)),
         }
         self.prior_dist = pdist.Uniform(**self.prior_params).to_event(1)
+        self.prior_dist.set_default_validate_args(False)
 
         self.simulator_params = {
             "a_low": -math.pi / 2.0,


### PR DESCRIPTION
In recent versions of PyTorch, default behavior for distributions changed to validate args by default. As consequence of this, evaluating an distribution out of its support throws an error rather than returning `torch(-inf)`. This PR restores the old behavior by disabling validation for the prior distributions. In the future, we might change the rejection sampling algorithms instead, by using `within_support` from `sbi`.