### PR TITLE
Disable `sbi` transforms added in v0.17.0

### DIFF
--- a/sbibm/algorithms/sbi/snle.py
+++ b/sbibm/algorithms/sbi/snle.py
@@ -107,6 +107,7 @@ def run(
     posteriors = []
     proposal = prior
     mcmc_parameters["warmup_steps"] = 25
+    mcmc_parameters["enable_transform"] = False  # NOTE: Disable `sbi` auto-transforms, since `sbibm` does its own
 
     for r in range(num_rounds):
         theta, x = inference.simulate_for_sbi(

--- a/sbibm/algorithms/sbi/snre.py
+++ b/sbibm/algorithms/sbi/snre.py
@@ -117,6 +117,7 @@ def run(
     posteriors = []
     proposal = prior
     mcmc_parameters["warmup_steps"] = 25
+    mcmc_parameters["enable_transform"] = False  # NOTE: Disable `sbi` auto-transforms, since `sbibm` does its own
 
     for r in range(num_rounds):
         theta, x = inference.simulate_for_sbi(

--- a/tests/algorithms/sbi/test_snle_posterior.py
+++ b/tests/algorithms/sbi/test_snle_posterior.py
@@ -18,7 +18,7 @@ from sbibm.metrics.c2st import c2st
         for num_observation in [1, 3]
     ],
 )
-def test_lpe_posterior(
+def test_nle_posterior(
     task_name, num_observation, num_simulations=2_000, num_samples=100
 ):
     task = sbibm.get_task(task_name)

--- a/tests/algorithms/sbi/test_snle_posterior.py
+++ b/tests/algorithms/sbi/test_snle_posterior.py
@@ -1,0 +1,47 @@
+import pytest
+import torch
+
+import sbibm
+from sbibm.algorithms.sbi.snle import run as run_posterior
+from sbibm.metrics.c2st import c2st
+
+
+# a fast test
+@pytest.mark.parametrize(
+    "task_name,num_observation",
+    [
+        (task_name, num_observation)
+        for task_name in [
+            "gaussian_linear",
+            "gaussian_linear_uniform",
+        ]
+        for num_observation in [1, 3]
+    ],
+)
+def test_lpe_posterior(
+    task_name, num_observation, num_simulations=2_000, num_samples=100
+):
+    task = sbibm.get_task(task_name)
+
+    predicted, _, _ = run_posterior(
+        task=task,
+        num_observation=num_observation,
+        num_simulations=num_simulations,
+        num_samples=num_samples,
+        num_rounds=1,
+        max_num_epochs=30,
+    )
+
+    reference_samples = task.get_reference_posterior_samples(
+        num_observation=num_observation
+    )
+
+    expected = reference_samples[:num_samples, :]
+
+    assert expected.shape == predicted.shape
+
+    acc = c2st(predicted, expected)
+
+    assert acc > 0.5
+    assert acc < 1.0
+    assert acc > 0.6

--- a/tests/algorithms/sbi/test_snre_posterior.py
+++ b/tests/algorithms/sbi/test_snre_posterior.py
@@ -1,0 +1,47 @@
+import pytest
+import torch
+
+import sbibm
+from sbibm.algorithms.sbi.snre import run as run_posterior
+from sbibm.metrics.c2st import c2st
+
+
+# a fast test
+@pytest.mark.parametrize(
+    "task_name,num_observation",
+    [
+        (task_name, num_observation)
+        for task_name in [
+            "gaussian_linear",
+            "gaussian_linear_uniform",
+        ]
+        for num_observation in [1, 3]
+    ],
+)
+def test_nre_posterior(
+    task_name, num_observation, num_simulations=2_000, num_samples=100
+):
+    task = sbibm.get_task(task_name)
+
+    predicted, _, _ = run_posterior(
+        task=task,
+        num_observation=num_observation,
+        num_simulations=num_simulations,
+        num_samples=num_samples,
+        num_rounds=1,
+        max_num_epochs=30,
+    )
+
+    reference_samples = task.get_reference_posterior_samples(
+        num_observation=num_observation
+    )
+
+    expected = reference_samples[:num_samples, :]
+
+    assert expected.shape == predicted.shape
+
+    acc = c2st(predicted, expected)
+
+    assert acc > 0.5
+    assert acc < 1.0
+    assert acc > 0.6


### PR DESCRIPTION
`sbi` v0.17.0 added automatic transforms for MCMC sampling. This PR disables this new feature, since `sbibm` is handling transforms in its own way. 

~~As part of this PR, I discovered a problem with the reinterpretation of batch dimensions as introduced recently in #27 -- I am still looking for the best alternative way to handle this.~~ Update: Done in #37.

Closes #35