### PR TITLE
Follow-up to #27

### DIFF
--- a/sbibm/tasks/two_moons/task.py
+++ b/sbibm/tasks/two_moons/task.py
@@ -165,7 +165,7 @@ class TwoMoons(Task):
         *args,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        return {"parameters": torch.distributions.transforms.identity_transform}
+        return {"parameters": torch.distributions.transforms.IndependentTransform(torch.distributions.transforms.identity_transform, 1) }
 
     def _get_log_prob_fn(
         self,

--- a/sbibm/utils/pyro.py
+++ b/sbibm/utils/pyro.py
@@ -81,7 +81,6 @@ def get_log_prob_fn(
     model_trace = poutine.trace(model).get_trace(*model_args, **model_kwargs)
 
     has_enumerable_sites = False
-    needs_independent_transform = True
     for name, node in model_trace.iter_stochastic_nodes():
         fn = node["fn"]
 

--- a/sbibm/utils/pyro.py
+++ b/sbibm/utils/pyro.py
@@ -98,7 +98,7 @@ def get_log_prob_fn(
         if automatic_transform_enabled:
             transforms[name] = biject_to(fn.support).inv
         else:
-            transforms[name] = dist.transforms.identity_transform
+            transforms[name] = dist.transforms.IndependentTransform(dist.transforms.identity_transform, 1)
 
     if implementation == "pyro":
         trace_prob_evaluator = TraceEinsumEvaluator(

--- a/tests/tasks/test_task_interface.py
+++ b/tests/tasks/test_task_interface.py
@@ -101,3 +101,17 @@ def test_reference_posterior_not_called(task_name):
         reference_samples = task.get_reference_posterior_samples(num_observation=1)
 
     assert task is not None
+
+
+@pytest.mark.parametrize("task_name", [tn for tn in (all_tasks - julia_tasks)])
+def test_transforms_shapes(task_name, batch_size=5):
+    task = get_task(task_name)
+    prior = task.get_prior()
+    samples = prior(num_samples=batch_size)
+
+    transforms = task._get_transforms(True)["parameters"]
+
+    ladj_shape = transforms.log_abs_det_jacobian(transforms(samples), samples).shape
+    assert ladj_shape == torch.Size([batch_size])
+
+    assert transforms is not None


### PR DESCRIPTION
Turns out the solution proposed in #27 to adapt the usage of `log_abs_det_jacobian` for torch>=1.8 was not ideal -- in particular, we only need to use the `IndependentTransform` when we *do not* request automatic transforms. The way we set up priors for the tasks, event dimensions are already declared. Wrapping twice will lead to unexpected behavior. This PR fixes this problem and adds new tests to detect related issues in the future.