### PR TITLE
Bugfix for likelihood of two_moons if log=False

### DIFF
--- a/sbibm/tasks/two_moons/task.py
+++ b/sbibm/tasks/two_moons/task.py
@@ -156,7 +156,7 @@ class TwoMoons(Task):
         )
 
         if len(torch.where(u < 0.0)[0]) > 0:
-            L[torch.where(u < 0.0)[0]] = -torch.tensor(math.inf) if log else 0.0
+            L[torch.where(u < 0.0)[0]] = -torch.tensor(math.inf)
 
         return L if log else torch.exp(L)
 


### PR DESCRIPTION
there was a bug in the likelihood of the two-moons simulator. It only affects the case where `log=False`. Without the suggested change, the exp() is computed twice: Once in the line in which I suggested the change and once [here](https://github.com/sbi-benchmark/sbibm/blob/fd691bdf4b47d62229ba0b0c0fba08c450d08b2a/sbibm/tasks/two_moons/task.py#L161)