### PR TITLE
fixed the gaussian mixture example

### DIFF
--- a/sbibm/tasks/gaussian_mixture/task.py
+++ b/sbibm/tasks/gaussian_mixture/task.py
@@ -69,15 +69,17 @@ class GaussianMixture(Task):
         """
 
         def simulator(parameters):
+            parameters = torch.atleast_2d(parameters)
             idx = pyro.sample(
                 "mixture_idx",
-                pdist.Categorical(probs=self.simulator_params["mixture_weights"]),
+                pdist.Categorical(probs=torch.tile(self.simulator_params["mixture_weights"][None],
+                                  (parameters.shape[0], 1)))
             )
             return pyro.sample(
                 "data",
                 pdist.Normal(
-                    loc=self.simulator_params["mixture_locs_factor"][idx] * parameters,
-                    scale=self.simulator_params["mixture_scales"][idx],
+                    loc=self.simulator_params["mixture_locs_factor"][idx][:, None] * parameters,
+                    scale=self.simulator_params["mixture_scales"][idx][:, None],
                 ),
             )
 


### PR DESCRIPTION
Not sure if this is pyro/torch-version dependent, but I found that if I gave a bunch of theta's at the same time, the samples will either all from the smaller Gaussian or all from the larger Gaussian.

I think the issue is that it uses the same single call of `pdist.Categorical` regardless of the input theta size. With a simple fix, now the samples look correct on my side.