### PR TITLE
Fix latest sample init strategy for snle and snre. 

### DIFF
--- a/sbibm/algorithms/sbi/snle.py
+++ b/sbibm/algorithms/sbi/snle.py
@@ -37,8 +37,8 @@ def run(
             "num_candidate_samples": 10000,
         },
     },
-    z_score_x: bool = True,
-    z_score_theta: bool = True,
+    z_score_x: str = "independent",
+    z_score_theta: str = "independent",
     max_num_epochs: Optional[int] = 2**31 - 1,
 ) -> Tuple[torch.Tensor, int, Optional[torch.Tensor]]:
     """Runs (S)NLE from `sbi`

--- a/sbibm/algorithms/sbi/snle.py
+++ b/sbibm/algorithms/sbi/snle.py
@@ -126,8 +126,6 @@ def run(
             show_train_summary=True,
             max_num_epochs=max_num_epochs,
         )
-        if r > 1:
-            mcmc_parameters["init_strategy"] = "latest_sample"
 
         posterior = inference_method.build_posterior(
             density_estimator=density_estimator,
@@ -135,6 +133,12 @@ def run(
             mcmc_method=mcmc_method,
             mcmc_parameters=mcmc_parameters,
         )
+        # Change init_strategy to latest_sample after second round.
+        if r > 1:
+            posterior.init_strategy = "latest_sample"
+            # copy init params from round 2 posterior.
+            posterior._mcmc_init_params = proposal._mcmc_init_params
+
         proposal = posterior.set_default_x(observation)
         posteriors.append(posterior)
 

--- a/sbibm/algorithms/sbi/snpe.py
+++ b/sbibm/algorithms/sbi/snpe.py
@@ -27,8 +27,8 @@ def run(
     training_batch_size: int = 10000,
     num_atoms: int = 10,
     automatic_transforms_enabled: bool = False,
-    z_score_x: bool = True,
-    z_score_theta: bool = True,
+    z_score_x: str = "independent",
+    z_score_theta: str = "independent",
     max_num_epochs: Optional[int] = 2**31 - 1,
 ) -> Tuple[torch.Tensor, int, Optional[torch.Tensor]]:
     """Runs (S)NPE from `sbi`

--- a/sbibm/algorithms/sbi/snre.py
+++ b/sbibm/algorithms/sbi/snre.py
@@ -137,13 +137,17 @@ def run(
             max_num_epochs=max_num_epochs,
             **inference_method_kwargs,
         )
-        if r > 1:
-            mcmc_parameters["init_strategy"] = "latest_sample"
+
         posterior = inference_method.build_posterior(
             density_estimator,
             mcmc_method=mcmc_method,
             mcmc_parameters=mcmc_parameters,
         )
+        # Change init_strategy to latest_sample after second round.
+        if r > 1:
+            posterior.init_strategy = "latest_sample"
+            # copy init params from round 2 posterior.
+            posterior._mcmc_init_params = proposal._mcmc_init_params
         proposal = posterior.set_default_x(observation)
         posteriors.append(posterior)
 

--- a/sbibm/algorithms/sbi/snre.py
+++ b/sbibm/algorithms/sbi/snre.py
@@ -38,8 +38,8 @@ def run(
             "num_candidate_samples": 10000,
         },
     },
-    z_score_x: bool = True,
-    z_score_theta: bool = True,
+    z_score_x: str = "independent",
+    z_score_theta: str = "independent",
     variant: str = "B",
     max_num_epochs: Optional[int] = 2**31 - 1,
 ) -> Tuple[torch.Tensor, int, Optional[torch.Tensor]]:

--- a/tests/algorithms/sbi/test_sbi_run_methods.py
+++ b/tests/algorithms/sbi/test_sbi_run_methods.py
@@ -15,12 +15,13 @@ def test_sbi_api(
     run_method, task_name, num_observation, num_simulations=2_000, num_samples=100
 ):
     task = sbibm.get_task(task_name)
+    num_rounds = 4
 
     if run_method in (mcabc, smcabc, sl):  # abc algorithms
         kwargs = dict()
     else:  # neural algorithms
         kwargs = dict(
-            num_rounds=2,
+            num_rounds=num_rounds,
             training_batch_size=100,
             neural_net="mlp" if run_method == snre else "maf",
         )


### PR DESCRIPTION
closes #56 

after round 2, we are using the latest posterior samples from the previous round as inits for the current round. 
The `posterior._mcmc_init_params` are set to the latest samples at the end of the `sample` method. 
With the new sampler interface, however, we are creating a new posterior object at every iteration so that the latest samples are not set. 
In this fix, we copy the `posterior._mcmc_init_params` from the proposal (posterior from previous round) to the newly created posterior of the current round. 

Independent from #56 , I here also adapt to the new z-scoring api (separate commit). 