### PR TITLE
Load GMM with weights_only set to False

### DIFF
--- a/sbibm/tasks/slcp/task.py
+++ b/sbibm/tasks/slcp/task.py
@@ -117,7 +117,7 @@ class SLCP(Task):
             else:
                 data = pyro.sample("data", data_dist).reshape((num_samples, 8))
 
-                gmm = torch.load(self.path / "files" / "gmm.torch")
+                gmm = torch.load(self.path / "files" / "gmm.torch", weights_only=False)
                 noise = gmm.sample((num_samples,)).type(data.dtype)
 
                 data_and_noise = torch.cat([data, noise], dim=1)


### PR DESCRIPTION
This pull request updates the GMM model loading logic in the `simulator` function (`sbibm/tasks/slcp/task.py`). Specifically, it sets `weights_only=False` in the `torch.load` call. This change is required because the default behavior in PyTorch has changed, and the call to the simulator fails otherwise.
